### PR TITLE
feat: adding rename and has to KeyValueInterface

### DIFF
--- a/.run/Start Backends for Test.run.xml
+++ b/.run/Start Backends for Test.run.xml
@@ -2,6 +2,7 @@
   <configuration default="false" name="Start Backends for Test" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
     <deployment type="docker-compose.yml">
       <settings>
+        <option name="envFilePath" value="" />
         <option name="removeVolumesOnComposeDown" value="true" />
         <option name="sourceFilePath" value="docker-compose.yml" />
       </settings>

--- a/src/AwsDynamoDbDriver.php
+++ b/src/AwsDynamoDbDriver.php
@@ -4,6 +4,7 @@ namespace ByJG\AnyDataset\NoSql;
 
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Result;
+use ByJG\AnyDataset\Core\Exception\NotImplementedException;
 use ByJG\AnyDataset\Core\GenericIterator;
 use ByJG\AnyDataset\Lists\ArrayDataset;
 use ByJG\Serializer\SerializerObject;
@@ -113,6 +114,10 @@ class AwsDynamoDbDriver implements KeyValueInterface, RegistrableInterface
         $raw = $awsResult;
         if ($awsResult instanceof Result) {
             $raw = $awsResult["Item"];
+        }
+
+        if (empty($raw)) {
+            return null;
         }
 
         array_walk($raw, function($val, $key) use (&$result) {
@@ -232,5 +237,16 @@ class AwsDynamoDbDriver implements KeyValueInterface, RegistrableInterface
     public static function schema()
     {
         return ["dynamo", "dynamodb"];
+    }
+
+    public function rename($oldKey, $newKey)
+    {
+        throw new NotImplementedException("DynamoDB cannot rename");
+    }
+
+    public function has($key, $options = [])
+    {
+        $value = $this->get($key, $options);
+        return !empty($value);
     }
 }

--- a/src/AwsS3Driver.php
+++ b/src/AwsS3Driver.php
@@ -214,4 +214,21 @@ class AwsS3Driver implements KeyValueInterface, RegistrableInterface
     {
         return "s3";
     }
+
+    public function rename($oldKey, $newKey)
+    {
+        $data = [
+            'Bucket' => $this->bucket,
+            'Key'    => $newKey,
+            'CopySource' => "{$this->bucket}/{$oldKey}",
+        ];
+
+        $this->s3Client->copyObject($data);
+        $this->remove($oldKey);
+    }
+
+    public function has($key, $options = [])
+    {
+        return $this->s3Client->doesObjectExistV2($this->bucket, $key, false, $options);
+    }
 }

--- a/src/CloudflareKV.php
+++ b/src/CloudflareKV.php
@@ -212,4 +212,14 @@ class CloudflareKV implements KeyValueInterface, RegistrableInterface
     {
         return "kv";
     }
+
+    public function rename($oldKey, $newKey)
+    {
+        // TODO: Implement rename() method.
+    }
+
+    public function has($key, $options = [])
+    {
+        // TODO: Implement has() method.
+    }
 }

--- a/src/KeyValueInterface.php
+++ b/src/KeyValueInterface.php
@@ -13,6 +13,8 @@ interface KeyValueInterface
      */
     public function getIterator($options = []);
 
+    public function has($key, $options = []);
+
     public function get($key, $options = []);
 
     public function put($key, $value, $options = []);
@@ -34,5 +36,7 @@ interface KeyValueInterface
     public function removeBatch($keys, $options = []);
 
     public function getDbConnection();
+
+    public function rename($oldKey, $newKey);
 
 }

--- a/tests/AwsDynamoDbDriverTest.php
+++ b/tests/AwsDynamoDbDriverTest.php
@@ -102,8 +102,12 @@ class AwsDynamoDbDriverTest extends TestCase
         $this->assertEquals(0, $iterator->count());
 
         // Add an element
+        $this->assertFalse($this->object->has(1, $this->options));
+        $this->assertFalse($this->object->has(2, $this->options));
         $this->object->put(1, ["Name" => "John", "SurName" => "Doe"], $this->options);
         $this->object->put(2, ["Name" => "Jane", "SurName" => "Smith"], $this->options);
+        $this->assertTrue($this->object->has(1, $this->options));
+        $this->assertTrue($this->object->has(2, $this->options));
 
         // Check new elements
         $iterator = $this->object->getIterator($this->queryOptions);

--- a/tests/AwsS3DriverTest.php
+++ b/tests/AwsS3DriverTest.php
@@ -85,4 +85,63 @@ class AwsS3DriverTest extends TestCase
         $this->assertEquals(str_repeat("1", 256), $part2);
         $this->assertEquals(str_repeat("2", 250), $part3);
     }
+
+    public function testRename()
+    {
+        if (empty($this->object)) {
+            $this->markTestIncomplete("In order to test S3 you must define S3_CONNECTION");
+        }
+
+        // Get current bucket
+        $iterator = $this->object->getIterator();
+        $currentCount = $iterator->count();
+
+        // Add an element
+        $this->object->put("KEY", "value");
+
+        // Check new elements
+        $iterator = $this->object->getIterator();
+        $this->assertEquals($currentCount + 1, $iterator->count());
+
+        // Get elements
+        $elem1 = $this->object->get("KEY");
+        $this->assertEquals("value", $elem1);
+        $this->assertFalse($this->object->has("NEW_KEY"));
+
+        // Rename elements
+        $this->object->rename("KEY", "NEW_KEY");
+        $elem1 = $this->object->get("NEW_KEY");
+        $this->assertEquals("value", $elem1);
+        $this->assertFalse($this->object->has("KEY"));
+
+        // Remove elements
+        $this->object->remove("NEW_KEY");
+
+        // Check new elements
+        $iterator = $this->object->getIterator();
+        $this->assertEquals($currentCount, $iterator->count());
+
+    }
+
+    public function testHas()
+    {
+        if (empty($this->object)) {
+            $this->markTestIncomplete("In order to test S3 you must define S3_CONNECTION");
+        }
+
+        // Assert key not exists
+        $this->assertFalse($this->object->has("KEY"));
+
+        // Add an element
+        $this->object->put("KEY", "value");
+
+        // Assert key exists
+        $this->assertTrue($this->object->has("KEY"));
+
+        // Remove an element
+        $this->object->remove("KEY");
+
+        // Assert key not exists
+        $this->assertFalse($this->object->has("KEY"));
+    }
 }


### PR DESCRIPTION
I am adding 2 methods to rename files into aws S3 and to verify if file/register exists on server

| Method | S3 | Dynamo | KV |
|--|--|--|--|
| rename() | yes | no | no |
| has() | yes | yes | no |